### PR TITLE
Fixed creating blog posts from dashlet

### DIFF
--- a/config/alfresco/site-webscripts/org/sharextras/components/dashlets/site-blog.get.head.ftl
+++ b/config/alfresco/site-webscripts/org/sharextras/components/dashlets/site-blog.get.head.ftl
@@ -1,10 +1,3 @@
-<#include "/org/alfresco/components/component.head.inc">
-<!-- Site Blog dashlet dependencies -->
-<@script type="text/javascript" src="${page.url.context}/modules/simple-dialog.js"></@script>
-<script type="text/javascript" src="${page.url.context}/modules/editors/tiny_mce/tiny_mce.js"></script>
-<@script type="text/javascript" src="${page.url.context}/modules/editors/tiny_mce.js"></@script>
-<@link rel="stylesheet" type="text/css" href="${page.url.context}/modules/taglibrary/taglibrary.css" />
-<@script type="text/javascript" src="${page.url.context}/modules/taglibrary/taglibrary.js"></@script>
-<!-- Site Blog dashlet -->
-<@script type="text/javascript" src="${page.url.context}/res/extras/components/dashlets/site-blog.js"></@script>
-<@link rel="stylesheet" type="text/css" href="${page.url.context}/res/extras/components/dashlets/site-blog.css" />
+<#-- PLEASE NOTE:
+<#-- Use of .head.ftl WebScript files has now been deprecated from WebScripts that render Share Components.    -->
+<#-- Dependencies are now loaded through the use of the <@script> and <@link> tags in the main .html.ftl file.  -->

--- a/config/alfresco/site-webscripts/org/sharextras/components/dashlets/site-blog.get.html.ftl
+++ b/config/alfresco/site-webscripts/org/sharextras/components/dashlets/site-blog.get.html.ftl
@@ -1,3 +1,19 @@
+<@markup id="css" >
+    <@link rel="stylesheet" type="text/css" href="${url.context}/res/modules/taglibrary/taglibrary.css" />
+    <@link rel="stylesheet" type="text/css" href="${url.context}/res/extras/components/dashlets/site-blog.css" />
+</@>
+
+
+<@markup id="js">
+    <#-- JavaScript Dependencies -->
+    <@script type="text/javascript" src="${url.context}/res/modules/simple-dialog.js" group="dashlets"></@script>
+    <@script type="text/javascript" src="${url.context}/res/modules/editors/tiny_mce/tiny_mce.js" group="dashlets"></@script>
+    <@script type="text/javascript" src="${url.context}/res/modules/editors/tiny_mce.js" group="dashlets"></@script>
+    <@script type="text/javascript" src="${url.context}/res/modules/taglibrary/taglibrary.js" group="dashlets"></@script>
+    <@script type="text/javascript" src="${url.context}/res/extras/components/dashlets/site-blog.js" group="dashlets"></@script>
+</@>
+
+
 <script type="text/javascript">//<![CDATA[
    var dashlet = new Alfresco.dashlet.SiteBlog("${args.htmlid}").setOptions(
    {


### PR DESCRIPTION
Creating blog posts from the dashlet was no longer working with 4.2.d, because the taglib.js (and other dependencies) could not be loaded.

Fixed.
